### PR TITLE
検索結果をクリックしてリダイレクトが行われない問題の修正

### DIFF
--- a/public/js/player-search.js
+++ b/public/js/player-search.js
@@ -16,11 +16,11 @@ $(document).ready(() => {
                 .css({
                     cursor: "pointer"
                 });
-            suggestion_container
-                .append(element)
-                .on("click", () => {
-                    window.location.href = "/player/" + player.name
-                });
+            element.on("click", () => {
+                window.location.href = "/player/" + player.name;
+            });
+
+            suggestion_container.append(element);
         });
 
         // if result not found
@@ -54,6 +54,6 @@ $(document).ready(() => {
         }
     });
     inputBox.focusout(() => {
-        suggestion_container.empty();
+//        suggestion_container.empty();
     });
 });


### PR DESCRIPTION
#41 での検索結果からのリダイレクトが行われない現象を修正しました。

Google Chrome(60.0.3112.101), Edgeでの動作を確認しています。
(バージョン等調べ次第追記/追加で検証します)

IE11はECMAScriptの新バージョンでの文法(アロー関数)等に対応していないそうですので、
トランスパイラを使うかESのバージョンを下げる等して対応する必要がありそうです。