### PR TITLE
ランキングAPIの実装

### DIFF
--- a/app/Http/Controllers/Api/PlayerRanking.php
+++ b/app/Http/Controllers/Api/PlayerRanking.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Api\PlayerRanking\BreakRankingResolver;
+use App\Http\Controllers\Api\PlayerRanking\BuildRankingResolver;
+use App\Http\Controllers\Api\PlayerRanking\PlaytimeRankingResolver;
+use App\Http\Controllers\Api\PlayerRanking\VoteRankingResolver;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class PlayerRanking extends Controller
+{
+    const DEFAULT_LIMIT_VALUE = 100;
+    const LIMIT_MAX = 100;
+
+    const DEFAULT_OFFSET_VALUE = 1;
+
+    private $resolvers;
+
+    public function __construct()
+    {
+        $this->resolvers = [
+            "default" => new BreakRankingResolver(),
+            "build" => new BuildRankingResolver(),
+            "playtime" => new PlaytimeRankingResolver(),
+            "vote" => new VoteRankingResolver()
+        ];
+    }
+
+    private function toJsonResult($ranks_result = [])
+    {
+        return response()->json([
+            'result_count' => count($ranks_result),
+            'ranks' => $ranks_result
+        ]);
+    }
+
+    private function fetch_ranking($ranking_type, $limit, $offset)
+    {
+        $resolver = isset($this->resolvers[$ranking_type]) ? $this->resolvers[$ranking_type] : $this->resolvers["default"];
+        return $resolver->getRanking($limit, $offset);
+    }
+
+    public function get(Request $request)
+    {
+        $ranking_type = $request->input("type") ?: "default";
+
+        $limit = (int) $request->input("lim") ?: self::DEFAULT_LIMIT_VALUE;
+        $limit = max(1, min($limit, self::LIMIT_MAX));
+
+        $offset = (int) $request->input("offset") ?: self::DEFAULT_OFFSET_VALUE;
+        $offset = max(1, $offset);
+
+        $ranks = $this->fetch_ranking($ranking_type, $limit, $offset);
+        return $this->toJsonResult($ranks);
+    }
+}

--- a/app/Http/Controllers/Api/PlayerRanking/BreakRankingResolver.php
+++ b/app/Http/Controllers/Api/PlayerRanking/BreakRankingResolver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api\PlayerRanking;
+
+
+class BreakRankingResolver extends RankingResolver
+{
+    const COMPARE_TARGET = 'totalbreaknum';
+    const RANKING_TYPE = 'break';
+
+    function getRankComparator()
+    {
+        return self::COMPARE_TARGET;
+    }
+
+    function getRankingType()
+    {
+        return self::RANKING_TYPE;
+    }
+}

--- a/app/Http/Controllers/Api/PlayerRanking/BuildRankingResolver.php
+++ b/app/Http/Controllers/Api/PlayerRanking/BuildRankingResolver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api\PlayerRanking;
+
+
+class BuildRankingResolver extends RankingResolver
+{
+    const COMPARE_TARGET = 'build_count';
+    const RANKING_TYPE = 'build';
+
+    function getRankComparator()
+    {
+        return self::COMPARE_TARGET;
+    }
+
+    function getRankingType()
+    {
+        return self::RANKING_TYPE;
+    }
+}

--- a/app/Http/Controllers/Api/PlayerRanking/PlaytimeRankingResolver.php
+++ b/app/Http/Controllers/Api/PlayerRanking/PlaytimeRankingResolver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api\PlayerRanking;
+
+
+class PlaytimeRankingResolver extends RankingResolver
+{
+    const COMPARE_TARGET = 'playtick';
+    const RANKING_TYPE = 'playtime';
+
+    function getRankComparator()
+    {
+        return self::COMPARE_TARGET;
+    }
+
+    function getRankingType()
+    {
+        return self::RANKING_TYPE;
+    }
+}

--- a/app/Http/Controllers/Api/PlayerRanking/RankingResolver.php
+++ b/app/Http/Controllers/Api/PlayerRanking/RankingResolver.php
@@ -10,12 +10,12 @@ abstract class RankingResolver
 
     abstract function getRankingType();
 
-    private function toPlayerRank($player)
+    private function toPlayerRank($ranked_player)
     {
-        $player_rank = $player->rank;
-        unset($player->rank);
+        $player_rank = $ranked_player->rank;
+        unset($ranked_player->rank);
         return [
-            "player" => $player,
+            "player" => $ranked_player,
             "type" => $this->getRankingType(),
             "rank" => $player_rank
         ];
@@ -44,5 +44,22 @@ abstract class RankingResolver
         }
 
         return array_slice($ranked_players, $offset - 1, $limit);
+    }
+
+    public function getPlayerRank($player_name)
+    {
+        $comparator = $this->getRankComparator();
+
+        // TODO this query cannot be cached, but instead a (name => rank) map can be generated from all-players-ranking
+        $ranked_player = DB::table('playerdata as t1')
+            ->select(
+                'name',
+                'uuid',
+                DB::raw('(select count(*)+1 from playerdata as t2 where t2.' . $comparator . ' > t1.' . $comparator . ') as rank')
+            )
+            ->where('name', $player_name)
+            ->first();
+
+        return $this->toPlayerRank($ranked_player);
     }
 }

--- a/app/Http/Controllers/Api/PlayerRanking/RankingResolver.php
+++ b/app/Http/Controllers/Api/PlayerRanking/RankingResolver.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Api\PlayerRanking;
+
+use DB;
+
+abstract class RankingResolver
+{
+    abstract function getRankComparator();
+
+    abstract function getRankingType();
+
+    private function toPlayerRank($player, $rank)
+    {
+        return [
+            "player" => $player,
+            "type" => $this->getRankingType(),
+            "rank" => $rank + 1
+        ];
+    }
+
+    public function getRanking($limit, $offset)
+    {
+        $comparator = $this->getRankComparator();
+
+        // TODO this result should be cached for better response time
+        $sorted_players = DB::table('playerdata as t1')
+            ->select('name', 'uuid')
+            ->where($comparator, '>', 0)
+            ->orderBy($comparator, 'DESC')
+            ->orderBy('name')
+            ->get();
+
+        $playerRanks = [];
+
+        foreach ($sorted_players as $rank=>$player) {
+            $playerRanks[] = $this->toPlayerRank($player, $rank);
+        }
+
+        return array_slice($playerRanks, $offset - 1, $limit);
+    }
+}

--- a/app/Http/Controllers/Api/PlayerRanking/VoteRankingResolver.php
+++ b/app/Http/Controllers/Api/PlayerRanking/VoteRankingResolver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api\PlayerRanking;
+
+
+class VoteRankingResolver extends RankingResolver
+{
+    const COMPARE_TARGET = 'p_vote';
+    const RANKING_TYPE = 'break';
+
+    function getRankComparator()
+    {
+        return self::COMPARE_TARGET;
+    }
+
+    function getRankingType()
+    {
+        return self::RANKING_TYPE;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,3 +21,5 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::get('/search/player', 'Api\PlayerSearch@get');
 
 Route::get('/ranking', 'Api\PlayerRanking@get');
+
+Route::get('/ranking/player/{player_name}', 'Api\PlayerRanking@getPlayerRank');

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,3 +19,5 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 
 // プレーヤー検索API
 Route::get('/search/player', 'Api\PlayerSearch@get');
+
+Route::get('/ranking', 'Api\PlayerRanking@get');


### PR DESCRIPTION
[Redmine #1650](https://w1.minecraftserver.jp/redmine/issues/1650)にある仕様でAPIを実装しました。

該当チケットからの変更点として、/api/rankingの結果のサイズ上限は`lim`パラメータとして実装しました。また、/api/ranking/player/{playername}の`types`パラメータは初期の予定通りカンマ区切りで指定するように実装しました。