### PR TITLE
ランキングエンドポイントの修正

### DIFF
--- a/app/Http/Controllers/Api/PlayerRanking.php
+++ b/app/Http/Controllers/Api/PlayerRanking.php
@@ -63,7 +63,7 @@ class PlayerRanking extends Controller
         ]);
     }
 
-    public function getPlayerRank(Request $request, $player_name)
+    public function getPlayerRank(Request $request, $player_uuid)
     {
         $ranking_resolvers = array();
         $ranking_types = $request->input("types") ?: self::DEFAULT_RANKING_TYPES;
@@ -76,7 +76,7 @@ class PlayerRanking extends Controller
 
         $ranks = array();
         foreach ($ranking_resolvers as $resolver) {
-            $rank = $resolver->getPlayerRank($player_name);
+            $rank = $resolver->getPlayerRank($player_uuid);
 
             if ($rank == null) {
                 return response()->json(["message" => "requested data does not exist."], 404);

--- a/app/Http/Controllers/Api/PlayerRanking/RankingResolver.php
+++ b/app/Http/Controllers/Api/PlayerRanking/RankingResolver.php
@@ -50,7 +50,7 @@ abstract class RankingResolver
         return array_slice($ranked_players, $offset - 1, $limit);
     }
 
-    public function getPlayerRank($player_name)
+    public function getPlayerRank($player_uuid)
     {
         $comparator = $this->getRankComparator();
 
@@ -61,7 +61,7 @@ abstract class RankingResolver
                 'uuid',
                 DB::raw('(select count(*)+1 from playerdata as t2 where t2.' . $comparator . ' > t1.' . $comparator . ') as rank')
             )
-            ->where('name', $player_name)
+            ->where('uuid', $player_uuid)
             ->first();
 
         return $this->toPlayerRank($ranked_player);

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,4 +22,4 @@ Route::get('/search/player', 'Api\PlayerSearch@get');
 
 Route::get('/ranking', 'Api\PlayerRanking@get');
 
-Route::get('/ranking/player/{player_name}', 'Api\PlayerRanking@getPlayerRank');
+Route::get('/ranking/player/{player_uuid}', 'Api\PlayerRanking@getPlayerRank');


### PR DESCRIPTION
プレーヤーのデータをUUIDから取得するほうが望ましいとのことですので、
`/api/ranking/player/{playername}`を
`/api/ranking/player/{player.uuid}`に変更しました。